### PR TITLE
Dynamic update

### DIFF
--- a/mappers/audit_log_mapper.go
+++ b/mappers/audit_log_mapper.go
@@ -6,14 +6,9 @@ import (
 	"fmt"
 
 	"github.com/turbot/tailpipe-plugin-github/rows"
-	"github.com/turbot/tailpipe-plugin-sdk/table"
 )
 
 type AuditLogMapper struct {
-}
-
-func NewAuditLogMapper() table.Mapper[*rows.AuditLog] {
-	return &AuditLogMapper{}
 }
 
 func (c *AuditLogMapper) Identifier() string {

--- a/tables/audit_log_table.go
+++ b/tables/audit_log_table.go
@@ -33,11 +33,11 @@ func (c *AuditLogTable) Identifier() string {
 	return AuditLogTableIdentifier
 }
 
-func (c *AuditLogTable) SupportedSources(_ *AuditLogTableConfig) []*table.SourceMetadata[*rows.AuditLog] {
+func (c *AuditLogTable) GetSourceMetadata(_ *AuditLogTableConfig) []*table.SourceMetadata[*rows.AuditLog] {
 	return []*table.SourceMetadata[*rows.AuditLog]{
 		{
 			SourceName: constants.ArtifactSourceIdentifier,
-			MapperFunc: mappers.NewAuditLogMapper,
+			Mapper:     &mappers.AuditLogMapper{},
 			Options: []row_source.RowSourceOption{
 				artifact_source.WithRowPerLine(),
 			},
@@ -45,10 +45,8 @@ func (c *AuditLogTable) SupportedSources(_ *AuditLogTableConfig) []*table.Source
 	}
 }
 
-func (c *AuditLogTable) EnrichRow(row *rows.AuditLog, sourceEnrichmentFields *enrichment.CommonFields) (*rows.AuditLog, error) {
-	if sourceEnrichmentFields != nil {
-		row.CommonFields = *sourceEnrichmentFields
-	}
+func (c *AuditLogTable) EnrichRow(row *rows.AuditLog, _ *AuditLogTableConfig, sourceEnrichmentFields enrichment.SourceEnrichment) (*rows.AuditLog, error) {
+	row.CommonFields = sourceEnrichmentFields.CommonFields
 
 	// Record standardization
 	row.TpID = xid.New().String()


### PR DESCRIPTION
- Source now passes SourceEnrichment struct to the Enrich function instead of just CommonFields
- Table.SupportedSources renamed to GetSourceMetadata
- MapperFunc is now just Mapper and should be populated with a mapper instance
- Pointless Mapper constructors removed
- EnrichRow now also takes a config param
- DelimitedLineMapper renamed to RowPatternMapper

